### PR TITLE
Fix for OpenCV color.simd_helpers.hpp assertion error

### DIFF
--- a/src/tc001.cpp
+++ b/src/tc001.cpp
@@ -1737,7 +1737,7 @@ void setScaleControls() {
 
 	// Scale Colormap Scale Widget width
 #if 1
-	ColorScaleWidth = 5 + MyScale;  // 5 to N
+	ColorScaleWidth = 6 + (MyScale / 2) * 2;  // Result is always even to fit for cvtColor using COLOR_YUV2BGR_YUYV
 #else
 	ColorScaleWidth = 3 + MyScale;  // 4 to N
 #endif


### PR DESCRIPTION
Fix mentioned in https://github.com/92es/Thermal-Camera-Redux/issues/4#issuecomment-2791347709 to make all `scale` settings work.